### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM maven
+
+COPY . /usr/src/app
+WORKDIR /usr/src/app
+
+RUN mvn clean package
+
+ENTRYPOINT [ "java", "-jar", "bin/POCDriver.jar" ]


### PR DESCRIPTION
Add Dockerfile to enable image building from source.
Using the official Maven image, 'latest' tag. If another version is needed/required/desirable, say so and I'll pin the parent image. More info at https://hub.docker.com/_/maven/

Just adding files and setting working dir. Entrypoint just runs plain jar file. Hostnames such as `localhost` won't work, since nothing else apart from the program runs inside the container, you have to look for the MongoDB server elsewhere outside the container by other means (a reachable IP, a Docker inter-container link, etc.)

Build:

```
$ docker build -t pocdriver .
```

Run (assuming an already running MongoDB listening on your LAN 192.x.x.x interface):

```
$ docker run --rm -it --name pocdriver pocdriver --host mongodb://192.x.x.x:27017 [other options...]
```

FYI, there's a still quicker to test, already built image on my Docker Hub. Test it by running:

```
$ docker run --rm -it --name pocdriver pataquets/pocdriver --host mongodb://192.x.x.x:27017 [other options...]
```

Using `--rm` instead of `-d` makes the container not go background. Stop it by `CTRL+C`'ing it.

Optional improvement to come:
- Create an 'official', based on your repo, automated build at Docker Hub for the image: https://docs.docker.com/docker-hub/builds/ . Just requires a free Docker Hub account and a following a quick 'Create automated build' process. You'll get a publicly usable Docker image builder triggered on every commit for free.