### PR TITLE
Use multi-stage build (available from docker 17.06)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM maven
-
+FROM maven AS build_img
 COPY . /usr/src/app
 WORKDIR /usr/src/app
-
 RUN mvn clean package
 
-ENTRYPOINT [ "java", "-jar", "bin/POCDriver.jar" ]
+
+FROM openjdk:7-jre
+COPY --from=build_img /usr/src/app/bin /javabin
+WORKDIR /javabin
+ENTRYPOINT [ "java", "-jar", "/javabin/POCDriver.jar" ]


### PR DESCRIPTION
Docker 17.06 introduce the [multi-stage build](https://docs.docker.com/engine/userguide/eng-image/multistage-build/) in this way we can use the maven image for building the jar and run it in a smaller image having just the jre.
With this change we go from a docker image of about 700MB to a one of 342MB
