### PR TITLE
Update on pom.xml to support Java 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,11 @@
   <artifactId>poc-driver</artifactId>
   <version>1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
+  
+  <properties>
+    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.6</maven.compiler.target>
+  </properties>
 
   <build>
     <plugins>


### PR DESCRIPTION
HI John,

I wasn't able to build POCDriver with Java 9. Adding the compiler source and target properties to the pom resolved the issue for me.

Cheers
Sepp