### PR TITLE
Add missing import in POCTestReporter.java

### DIFF
--- a/src/main/java/com/johnlpage/pocdriver/POCTestReporter.java
+++ b/src/main/java/com/johnlpage/pocdriver/POCTestReporter.java
@@ -6,6 +6,9 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.HashMap;
+import java.util.Date;
+import java.text.SimpleDateFormat;
+import java.text.DateFormat;
 
 import org.bson.Document;
 


### PR DESCRIPTION
Hello,
First, thanks for this project. With this current version, when I try to package, I have this error:

_[ERROR] COMPILATION ERROR :
[INFO] -------------------------------------------------------------
[ERROR] /tools/POCDriver/src/main/java/com/johnlpage/pocdriver/POCTestReporter.java:[75,33] cannot find symbol
  symbol:   class Date
  location: class com.johnlpage.pocdriver.POCTestReporter
[ERROR] /tools/POCDriver/src/main/java/com/johnlpage/pocdriver/POCTestReporter.java:[75,55] cannot find symbol
  symbol:   class Date
  location: class com.johnlpage.pocdriver.POCTestReporter
[ERROR] /tools/POCDriver/src/main/java/com/johnlpage/pocdriver/POCTestReporter.java:[76,33] cannot find symbol
  symbol:   class DateFormat
  location: class com.johnlpage.pocdriver.POCTestReporter
[ERROR] /tools/POCDriver/src/main/java/com/johnlpage/pocdriver/POCTestReporter.java:[76,54] cannot find symbol
  symbol:   class SimpleDateFormat
  location: class com.johnlpage.pocdriver.POCTestReporter
[INFO] 4 errors_

this PR adds missing imports.