### PR TITLE
Support multiple latency threshold values

### DIFF
--- a/src/main/java/com/johnlpage/pocdriver/MongoWorker.java
+++ b/src/main/java/com/johnlpage/pocdriver/MongoWorker.java
@@ -561,8 +561,7 @@ public class MongoWorker implements Runnable {
 
             }
 
-        } catch (Exception e) {
-            e.printStackTrace();
+        } catch (Exception e) {            
             System.out.println("Error: " + e.getMessage());
             if (testOpts.debug)
                 e.printStackTrace();

--- a/src/main/java/com/johnlpage/pocdriver/MongoWorker.java
+++ b/src/main/java/com/johnlpage/pocdriver/MongoWorker.java
@@ -336,7 +336,7 @@ public class MongoWorker implements Runnable {
 
             Date endtime = new Date();
             Long taken = endtime.getTime() - starttime.getTime();
-            recordSlowOps("keyquries", taken, 1);
+            recordSlowOps("keyqueries", taken, 1);
             testResults.RecordOpsDone("keyqueries", 1);
         }
         return myDoc;

--- a/src/main/java/com/johnlpage/pocdriver/POCDriver.java
+++ b/src/main/java/com/johnlpage/pocdriver/POCDriver.java
@@ -19,7 +19,7 @@ public class POCDriver {
 
         POCTestOptions testOpts;
         LogManager.getLogManager().reset();
-        System.out.println("MongoDB Proof Of Concept - Load Generator version 0.1.0");
+        System.out.println("MongoDB Proof Of Concept - Load Generator version 0.1.2");
         try {
             testOpts = new POCTestOptions(args);
             // Quit after displaying help message

--- a/src/main/java/com/johnlpage/pocdriver/POCDriver.java
+++ b/src/main/java/com/johnlpage/pocdriver/POCDriver.java
@@ -19,7 +19,7 @@ public class POCDriver {
 
         POCTestOptions testOpts;
         LogManager.getLogManager().reset();
-        System.out.println("MongoDB Proof Of Concept - Load Generator");
+        System.out.println("MongoDB Proof Of Concept - Load Generator version 0.1.0");
         try {
             testOpts = new POCTestOptions(args);
             // Quit after displaying help message
@@ -41,7 +41,7 @@ public class POCDriver {
             return;
         }
 
-        POCTestResults testResults = new POCTestResults();
+        POCTestResults testResults = new POCTestResults(testOpts);
         LoadRunner runner = new LoadRunner(testOpts);
         runner.RunLoad(testOpts, testResults);
     }

--- a/src/main/java/com/johnlpage/pocdriver/POCTestOptions.java
+++ b/src/main/java/com/johnlpage/pocdriver/POCTestOptions.java
@@ -20,9 +20,8 @@ public class POCTestOptions {
 	int textFieldLen = 30;
 	int numThreads = 4;
 	int threadIdStart = 0;
-	int reportTime = 10;
-	int slowThreshold = 50;
-	int[] slowThresholds = null;
+	int reportTime = 10;	
+	int[] slowThresholds = new int[]{50};  // default to 50
 	int insertops = 100;
 	int opsPerSecond = 0;
 	int keyqueries = 0;
@@ -232,7 +231,7 @@ public class POCTestOptions {
 			for(int i=0;i<strs.length;i++){
 				slowThresholds[i] = Integer.parseInt( strs[i]);
 			}			
-		}
+		}	
 		
 		// automatically generate the help statement
 		if(cmd.hasOption("h"))

--- a/src/main/java/com/johnlpage/pocdriver/POCTestOptions.java
+++ b/src/main/java/com/johnlpage/pocdriver/POCTestOptions.java
@@ -226,8 +226,7 @@ public class POCTestOptions {
 		}
 		
 		if(cmd.hasOption("s"))
-		{
-			//slowThreshold = Integer.parseInt(cmd.getOptionValue("s"));
+		{			
 			String[] strs = cmd.getOptionValue("s").split(",");
 			slowThresholds = new int[strs.length];
 			for(int i=0;i<strs.length;i++){

--- a/src/main/java/com/johnlpage/pocdriver/POCTestOptions.java
+++ b/src/main/java/com/johnlpage/pocdriver/POCTestOptions.java
@@ -22,6 +22,7 @@ public class POCTestOptions {
 	int threadIdStart = 0;
 	int reportTime = 10;
 	int slowThreshold = 50;
+	int[] slowThresholds = null;
 	int insertops = 100;
 	int opsPerSecond = 0;
 	int keyqueries = 0;
@@ -89,7 +90,7 @@ public class POCTestOptions {
 		cliopt.addOption("p","print",false,"Print out a sample document according to the other parameters then quit");
 		cliopt.addOption("q","opsPerSecond",true,"Try to rate limit the total ops/s to the specified amount");
 		cliopt.addOption("r","rangequeries",true,"Ratio of range query operations (default 0)");
-		cliopt.addOption("s","slowthreshold",true,"Slow operation threshold in ms(default 50)");
+		cliopt.addOption("s","slowthreshold",true,"Slow operation threshold in ms, use comma to separate multiple thresholds(default 50)");
 		cliopt.addOption("t","threads",true,"Number of threads (default 4)");
 		cliopt.addOption("u","updates",true,"Ratio of update operations (default 0)");
 		cliopt.addOption("v","workflow",true,"Specify a set of ordered operations per thread from [iukp]");
@@ -226,7 +227,12 @@ public class POCTestOptions {
 		
 		if(cmd.hasOption("s"))
 		{
-			slowThreshold = Integer.parseInt(cmd.getOptionValue("s"));
+			//slowThreshold = Integer.parseInt(cmd.getOptionValue("s"));
+			String[] strs = cmd.getOptionValue("s").split(",");
+			slowThresholds = new int[strs.length];
+			for(int i=0;i<strs.length;i++){
+				slowThresholds[i] = Integer.parseInt( strs[i]);
+			}			
 		}
 		
 		// automatically generate the help statement

--- a/src/main/java/com/johnlpage/pocdriver/POCTestReporter.java
+++ b/src/main/java/com/johnlpage/pocdriver/POCTestReporter.java
@@ -75,20 +75,29 @@ public class POCTestReporter implements Runnable {
             }
 
             Long opsDone = testResults.GetOpsDone(o);
-            if (opsDone > 0) {
-                Double fastops = 100 - (testResults.GetSlowOps(o) * 100.0)
-                        / opsDone;
-                System.out.format("%.2f %% in under %d milliseconds", fastops,
-                        testOpts.slowThreshold);
-                if (outfile != null) {
-                    outfile.format(",%.2f", fastops);
+
+            for(int i=0;i< testOpts.slowThresholds.length;i++){
+                int slowThreshold  =  testOpts.slowThresholds[i];
+                if (opsDone > 0) {
+                    Double fastops = 100 - (testResults.GetSlowOps(o, i) * 100.0)
+                            / opsDone;
+                    System.out.println();
+                    System.out.format("\t%.2f %% in under %d milliseconds", fastops,
+                            slowThreshold);
+                    if (outfile != null) {
+                        outfile.format(",%.2f", fastops);
+                    }
+                } else {
+                    System.out.println();
+                    System.out.format("\t%.2f %% in under %d milliseconds", (float) 100, slowThreshold);
+                    if (outfile != null) {
+                        outfile.format(",%d", 100);
+                    }
                 }
-            } else {
-                System.out.format("%.2f %% in under %d milliseconds", (float) 100, testOpts.slowThreshold);
-                if (outfile != null) {
-                    outfile.format(",%d", 100);
-                }
+                
             }
+
+            
             System.out.println();
 
         }

--- a/src/main/java/com/johnlpage/pocdriver/POCTestResults.java
+++ b/src/main/java/com/johnlpage/pocdriver/POCTestResults.java
@@ -88,6 +88,7 @@ public class POCTestResults {
     public void RecordSlowOp(String opType, int number, int thresholdIndex) {
         POCopStats os = opStats.get(opType);        
         os.slowOps[thresholdIndex].addAndGet(number);
+        
     }
 
     public void RecordOpsDone(String opType, int howmany) {
@@ -98,6 +99,4 @@ public class POCTestResults {
             os.totalOpsDone.addAndGet(howmany);
         }
     }
-
-
 }

--- a/src/main/java/com/johnlpage/pocdriver/POCTestResults.java
+++ b/src/main/java/com/johnlpage/pocdriver/POCTestResults.java
@@ -79,20 +79,12 @@ public class POCTestResults {
         return os.totalOpsDone.get();
     }
 
-
-    // public Long GetSlowOps(String opType) {
-    //     POCopStats os = opStats.get(opType);
-    //     return os.slowOps.get();
-    // }
+    
     public Long GetSlowOps(String opType, int thresholdIndex) {
         POCopStats os = opStats.get(opType);
         return os.slowOps[thresholdIndex].get();
     }
 
-    // public void RecordSlowOp(String opType, int number) {
-    //     POCopStats os = opStats.get(opType);
-    //     os.slowOps.addAndGet(number);
-    // }
     public void RecordSlowOp(String opType, int number, int thresholdIndex) {
         POCopStats os = opStats.get(opType);        
         os.slowOps[thresholdIndex].addAndGet(number);

--- a/src/main/java/com/johnlpage/pocdriver/POCTestResults.java
+++ b/src/main/java/com/johnlpage/pocdriver/POCTestResults.java
@@ -4,6 +4,7 @@ package com.johnlpage.pocdriver;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 
 public class POCTestResults {
@@ -19,13 +20,18 @@ public class POCTestResults {
     private ConcurrentHashMap<String, POCopStats> opStats;
 
 
-    POCTestResults() {
+    POCTestResults(POCTestOptions testOptions) {
         startTime = new Date();
         lastIntervalTime = new Date();
         opStats = new ConcurrentHashMap<String, POCopStats>();
 
         for (String s : opTypes) {
-            opStats.put(s, new POCopStats());
+            POCopStats stats = new POCopStats();
+            stats.slowOps = new AtomicLong[ testOptions.slowThresholds.length];            
+            for(int i =0; i< testOptions.slowThresholds.length; i++){
+                stats.slowOps[i] = new AtomicLong();
+            }
+            opStats.put(s, stats);
         }
     }
 
@@ -74,14 +80,22 @@ public class POCTestResults {
     }
 
 
-    public Long GetSlowOps(String opType) {
+    // public Long GetSlowOps(String opType) {
+    //     POCopStats os = opStats.get(opType);
+    //     return os.slowOps.get();
+    // }
+    public Long GetSlowOps(String opType, int thresholdIndex) {
         POCopStats os = opStats.get(opType);
-        return os.slowOps.get();
+        return os.slowOps[thresholdIndex].get();
     }
 
-    public void RecordSlowOp(String opType, int number) {
-        POCopStats os = opStats.get(opType);
-        os.slowOps.addAndGet(number);
+    // public void RecordSlowOp(String opType, int number) {
+    //     POCopStats os = opStats.get(opType);
+    //     os.slowOps.addAndGet(number);
+    // }
+    public void RecordSlowOp(String opType, int number, int thresholdIndex) {
+        POCopStats os = opStats.get(opType);        
+        os.slowOps[thresholdIndex].addAndGet(number);
     }
 
     public void RecordOpsDone(String opType, int howmany) {

--- a/src/main/java/com/johnlpage/pocdriver/POCopStats.java
+++ b/src/main/java/com/johnlpage/pocdriver/POCopStats.java
@@ -7,11 +7,12 @@ import java.util.concurrent.atomic.AtomicLong;
 public class POCopStats {
     public AtomicLong intervalCount;
     public AtomicLong totalOpsDone;
-    public AtomicLong slowOps;
+    public AtomicLong slowOps[];
 
     POCopStats() {
         intervalCount = new AtomicLong(0);
         totalOpsDone = new AtomicLong(0);
-        slowOps = new AtomicLong(0);
+        //slowOps = new AtomicLong(0);
+        
     }
 }


### PR DESCRIPTION
This allows the tool to track the latency performance at different latency threshold. For instance, one may be interested to see how many were under 10ms, how many were under 50ms, how many were under 100ms etc. 