### PR TITLE
Fixed Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# Editors
+.vscode
+.idea
+
+# Binary dirs
+bin
+target
+
+# Docs
+docs
+README.md
+
+# Docker
+# Don't invalidate cache just because Dockerfile changed
+Dockerfile
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /usr/src/app
 RUN mvn clean package
 
 
-FROM openjdk:7-jre
+FROM eclipse-temurin:11
 COPY --from=build_img /usr/src/app/bin /javabin
 WORKDIR /javabin
 ENTRYPOINT [ "java", "-jar", "/javabin/POCDriver.jar" ]


### PR DESCRIPTION
The build works, but the resulting image errors:

```console
$ podman build . -t pocdriver
...

$ podman run --rm -it pocdriver --help
Exception in thread "main" java.lang.UnsupportedClassVersionError: com/johnlpage/pocdriver/POCDriver : Unsupported major.minor version 52.0
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:808)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:443)
	at java.net.URLClassLoader.access$100(URLClassLoader.java:65)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:355)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:349)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:348)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:430)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:323)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:363)
	at sun.launcher.LauncherHelper.checkAndLoadMain(LauncherHelper.java:482)
```

Now with these changes it runs successfully:

```console
$ podman run --rm -it pocdriver --help
11:23:42.759 [main] INFO  com.johnlpage.pocdriver.POCDriver - 26 - MongoDB Proof Of Concept  - Load Generator version 0.1.2
usage: POCDriver
 -a,--arrays <arg>          Shape of any arrays in new sample documents
                            x:y so -a 12:60 adds an array of 12 length 60
                            arrays of integers
 -b,--bulksize <arg>        Bulk op size (default 512)
    --binary <arg>          Add a binary blob of size KB
 -c,--host <arg>            MongoDB connection details (default
```

I also added a `.dockerignore` so that the Docker build layer cache doesn't invalidate unnecessarily
